### PR TITLE
I propose to remove python 3.5 support

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.6', '3.7', '3.8', '3.9']
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Python 3.5 reached the end of its life on September 13th, 2020.

Further, knowing that

    pip 21.0 will drop support for Python 3.5 in January 2021.

I believe that maintaining our pipeline on python 3.5 will become increasingly
expensive over time.